### PR TITLE
fix v2 async support

### DIFF
--- a/src/Recaptcha.Web/RecaptchaVerificationHelper.cs
+++ b/src/Recaptcha.Web/RecaptchaVerificationHelper.cs
@@ -196,20 +196,25 @@ namespace Recaptcha.Web
         /// <returns>Returns the result as a value of the <see cref="RecaptchaVerificationResult"/> enum.</returns>
         public Task<RecaptchaVerificationResult> VerifyRecaptchaResponseTaskAsync()
         {
-            if (string.IsNullOrEmpty(_challenge))
-            {
-                return FromTaskResult<RecaptchaVerificationResult>(RecaptchaVerificationResult.ChallengeNotProvided);
-            }
-
             if (string.IsNullOrEmpty(Response))
             {
                 return FromTaskResult<RecaptchaVerificationResult>(RecaptchaVerificationResult.NullOrEmptyCaptchaSolution);
             }
 
+            string privateKey = RecaptchaKeyHelper.ParseKey(PrivateKey);
+
+            if (_isVersion2)
+            {
+                return VerifyRecpatcha2ResponseTaskAsync(privateKey);
+            }
+
+            if (string.IsNullOrEmpty(_challenge))
+            {
+                return FromTaskResult<RecaptchaVerificationResult>(RecaptchaVerificationResult.ChallengeNotProvided);
+            }
+
             Task<RecaptchaVerificationResult> result = Task<RecaptchaVerificationResult>.Factory.StartNew(() =>
             {
-                string privateKey = RecaptchaKeyHelper.ParseKey(PrivateKey);
-
                 string postData = String.Format("privatekey={0}&remoteip={1}&challenge={2}&response={3}", privateKey, this.UserHostAddress, this._challenge, this.Response);
 
                 byte[] postDataBuffer = System.Text.Encoding.ASCII.GetBytes(postData);


### PR DESCRIPTION
check for v2 request before '_challenge' (as that is always null on v2 requests)