### PR TITLE
error-codes is optional

### DIFF
--- a/src/Recaptcha.Web/RecaptchaVerificationHelper.cs
+++ b/src/Recaptcha.Web/RecaptchaVerificationHelper.cs
@@ -400,7 +400,12 @@ namespace Recaptcha.Web
                 return RecaptchaVerificationResult.Success;
             }
 
-            switch (result.ErrorCodes[0])
+			if (result.ErrorCodes == null || result.ErrorCodes.Length == 0)
+			{
+				return RecaptchaVerificationResult.UnknownError;
+			}
+
+			switch (result.ErrorCodes[0])
             {
                 case "missing-input-secret":
                     return RecaptchaVerificationResult.InvalidPrivateKey;


### PR DESCRIPTION
According to recaptcha documentation, error-codes is optional (see [https://developers.google.com/recaptcha/docs/verify#api-response](https://developers.google.com/recaptcha/docs/verify#api-response)).

The proposed change checks if error-codes exists before accessing it.