### PR TITLE
Added client callback properties for v2

### DIFF
--- a/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
+++ b/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
@@ -16,77 +16,79 @@ using System.Web.UI;
 
 namespace Recaptcha.Web.Mvc
 {
+  /// <summary>
+  /// Represents the Recaptcha method extensions container for the <see cref="System.Web.Mvc.HtmlHelper"/> and <see cref="System.Web.Mvc.Controller"/> classes.
+  /// </summary>
+  public static class RecaptchaMvcExtensions
+  {
+    #region Public Methods
+
     /// <summary>
-    /// Represents the Recaptcha method extensions container for the <see cref="System.Web.Mvc.HtmlHelper"/> and <see cref="System.Web.Mvc.Controller"/> classes.
+    /// Renders the recaptcha HTML in an MVC view. It is an extension method to the <see cref="System.Web.Mvc.HtmlHelper"/> class.
     /// </summary>
-    public static class RecaptchaMvcExtensions
+    /// <param name="htmlHelper">The <see cref="System.Web.Mvc.HtmlHelper"/> object to which the extension is added.</param>
+    /// <param name="publicKey">Sets the public key of recaptcha.</param>
+    /// <param name="theme">Sets the theme of recaptcha.</param>
+    /// <param name="language">Sets the language of recaptcha. If no language is specified, the language of the current UI culture will be used.</param>
+    /// <param name="tabIndex">Sets the tab index of recaptcha.</param>
+    /// <param name="dataType">Sets the data type of recaptcha.</param>
+    /// <param name="dataSize">Sets the size of recaptcha.</param>
+    /// <param name="useSsl">Sets the value to the UseSsl property.</param>
+    /// <param name="apiVersion">Determines the version of the reCAPTCHA API.</param>
+    /// <returns>Returns an instance of the IHtmlString type.</returns>
+    public static IHtmlString Recaptcha(
+        this HtmlHelper htmlHelper,
+        string publicKey = "{recaptchaPublicKey}",
+        RecaptchaTheme theme = RecaptchaTheme.Red,
+        string language = null,
+        int tabIndex = 0,
+        RecaptchaDataType? dataType = null,
+        RecaptchaDataSize? dataSize = null,
+        SslBehavior useSsl = SslBehavior.SameAsRequestUrl,
+        string apiVersion = "{recaptchaApiVersion}",
+        string dataCallback = "",
+        string dataExpiredCallback = "")
     {
-        #region Public Methods
+      IRecaptchaHtmlHelper rHtmlHelper = null;
 
-        /// <summary>
-        /// Renders the recaptcha HTML in an MVC view. It is an extension method to the <see cref="System.Web.Mvc.HtmlHelper"/> class.
-        /// </summary>
-        /// <param name="htmlHelper">The <see cref="System.Web.Mvc.HtmlHelper"/> object to which the extension is added.</param>
-        /// <param name="publicKey">Sets the public key of recaptcha.</param>
-        /// <param name="theme">Sets the theme of recaptcha.</param>
-        /// <param name="language">Sets the language of recaptcha. If no language is specified, the language of the current UI culture will be used.</param>
-        /// <param name="tabIndex">Sets the tab index of recaptcha.</param>
-        /// <param name="dataType">Sets the data type of recaptcha.</param>
-        /// <param name="dataSize">Sets the size of recaptcha.</param>
-        /// <param name="useSsl">Sets the value to the UseSsl property.</param>
-        /// <param name="apiVersion">Determines the version of the reCAPTCHA API.</param>
-        /// <returns>Returns an instance of the IHtmlString type.</returns>
-        public static IHtmlString Recaptcha(
-            this HtmlHelper htmlHelper,
-            string publicKey = "{recaptchaPublicKey}",
-            RecaptchaTheme theme = RecaptchaTheme.Red,
-            string language = null,
-            int tabIndex = 0,
-            RecaptchaDataType? dataType = null,
-            RecaptchaDataSize? dataSize = null,
-            SslBehavior useSsl = SslBehavior.SameAsRequestUrl,
-            string apiVersion = "{recaptchaApiVersion}")
-        {
-            IRecaptchaHtmlHelper rHtmlHelper = null;
+      string version = RecaptchaKeyHelper.ParseKey(apiVersion);
 
-            string version = RecaptchaKeyHelper.ParseKey(apiVersion);
+      if (version != "2")
+      {
+        rHtmlHelper = new RecaptchaHtmlHelper(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback);
+      }
+      else
+      {
+        rHtmlHelper = new Recaptcha2HtmlHelper(publicKey, theme, language, tabIndex, dataType, dataSize, useSsl, dataCallback, dataExpiredCallback);
+      }
 
-            if (version != "2")
-            {
-                rHtmlHelper = new RecaptchaHtmlHelper(publicKey, theme, language, tabIndex, useSsl);
-            }
-            else
-            {
-                rHtmlHelper = new Recaptcha2HtmlHelper(publicKey, theme, language, tabIndex, dataType, dataSize, useSsl);
-            }
+      var writer = new HtmlTextWriter(new StringWriter());
+      writer.Write(rHtmlHelper.ToString());
 
-            var writer = new HtmlTextWriter(new StringWriter());
-            writer.Write(rHtmlHelper.ToString());
-
-            return htmlHelper.Raw(writer.InnerWriter.ToString());
-        }
-
-        /// <summary>
-        /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
-        /// </summary>
-        /// <param name="controller">The <see cref="System.Web.Mvc.Controller"/> object to which the extension method is added to.</param>
-        /// <param name="privateKey">The private key required for making the recaptcha verification request.</param>
-        /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
-        public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this System.Web.Mvc.Controller controller, string privateKey)
-        {
-            return new RecaptchaVerificationHelper(privateKey);
-        }
-
-        /// <summary>
-        /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
-        /// </summary>
-        /// <param name="controller">The <see cref="System.Web.Mvc.Controller"/> object to which the extension method is added to.</param>
-        /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
-        public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this System.Web.Mvc.Controller controller)
-        {
-            return new RecaptchaVerificationHelper("{recaptchaPrivateKey}");
-        }
-
-        #endregion Public Methods
+      return htmlHelper.Raw(writer.InnerWriter.ToString());
     }
+
+    /// <summary>
+    /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
+    /// </summary>
+    /// <param name="controller">The <see cref="System.Web.Mvc.Controller"/> object to which the extension method is added to.</param>
+    /// <param name="privateKey">The private key required for making the recaptcha verification request.</param>
+    /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
+    public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this System.Web.Mvc.Controller controller, string privateKey)
+    {
+      return new RecaptchaVerificationHelper(privateKey);
+    }
+
+    /// <summary>
+    /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
+    /// </summary>
+    /// <param name="controller">The <see cref="System.Web.Mvc.Controller"/> object to which the extension method is added to.</param>
+    /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
+    public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this System.Web.Mvc.Controller controller)
+    {
+      return new RecaptchaVerificationHelper("{recaptchaPrivateKey}");
+    }
+
+    #endregion Public Methods
+  }
 }

--- a/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
+++ b/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
@@ -55,7 +55,7 @@ namespace Recaptcha.Web.Mvc
 
       if (version != "2")
       {
-        rHtmlHelper = new RecaptchaHtmlHelper(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback);
+        rHtmlHelper = new RecaptchaHtmlHelper(publicKey, theme, language, tabIndex, useSsl);
       }
       else
       {

--- a/src/Recaptcha.Web/Recaptcha2HtmlHelper.cs
+++ b/src/Recaptcha.Web/Recaptcha2HtmlHelper.cs
@@ -13,192 +13,223 @@ using System.Web;
 
 namespace Recaptcha.Web
 {
+  /// <summary>
+  /// Represents the functionality to generate HTML for Recaptcha API v2.0.
+  /// </summary>
+  public class Recaptcha2HtmlHelper : RecaptchaHtmlHelperBase
+  {
+    #region Constructors
+
     /// <summary>
-    /// Represents the functionality to generate HTML for Recaptcha API v2.0.
+    /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
     /// </summary>
-    public class Recaptcha2HtmlHelper : RecaptchaHtmlHelperBase
+    /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
+    public Recaptcha2HtmlHelper(string publicKey)
+        : base(publicKey)
     {
-        #region Constructors
-
-        /// <summary>
-        /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
-        public Recaptcha2HtmlHelper(string publicKey)
-            : base(publicKey)
-        {
-            DataType = null;
-            DataSize = null;
-        }
-
-        /// <summary>
-        /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>   
-        public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
-            : base(publicKey, theme, language, tabIndex)
-        {
-            DataType = null;
-            DataSize = null;
-        }
-
-        /// <summary>
-        /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-        /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
-        public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
-            : base(publicKey, theme, language, tabIndex, useSsl)
-        {
-            DataType = null;
-            DataSize = null;
-        }
-
-        /// <summary>
-        /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-        /// <param name="dataType">Sets the type of the recaptcha HTML.</param>
-        /// <param name="dataSize">Sets the size for the recpatcha HTML.</param>
-        /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
-        public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, RecaptchaDataType? dataType, RecaptchaDataSize? dataSize, SslBehavior useSsl)
-            : base(publicKey, theme, language, tabIndex, useSsl)
-        {
-            DataType = dataType;
-            DataSize = dataSize;
-        }
-
-        #endregion Constructors
-
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the size of the reCAPTCHA control.
-        /// </summary>
-        public RecaptchaDataSize? DataSize
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets they type of the reCAPTCHA control.
-        /// </summary>
-        public RecaptchaDataType? DataType
-        {
-            get;
-            set;
-        }
-
-        #endregion Properties
-
-        #region Public Methods
-
-        /// <summary>
-        /// Gets the recaptcha's HTML that needs to be rendered in an HTML page.
-        /// </summary>
-        /// <returns>Returns the HTML as an instance of the <see cref="String"/> type.</returns>
-        public override string ToString()
-        {
-            StringBuilder sb = new StringBuilder();
-
-            string lang = "";
-
-            if (!String.IsNullOrEmpty(Language))
-            {
-                lang = string.Format("?hl={0}", Language);
-            }
-
-            bool doUseSsl = false;
-
-            if (UseSsl == SslBehavior.DoNotUseSsl)
-            {
-                doUseSsl = false;
-            }
-            else if (UseSsl == SslBehavior.AlwaysUseSsl)
-            {
-                doUseSsl = true;
-            }
-            else if (UseSsl == SslBehavior.SameAsRequestUrl)
-            {
-                doUseSsl = HttpContext.Current.Request.IsSecureConnection;
-            }
-
-            var protocol = "https://";
-
-            if (!doUseSsl)
-            {
-                protocol = "http://";
-            }
-
-            sb.Append(string.Format("<script src=\"{0}www.google.com/recaptcha/api.js{1}\" async defer></script>", protocol, lang));
-            sb.Append(string.Format("<div class=\"g-recaptcha\" data-sitekey=\"{0}\"", PublicKey));
-
-            if (Theme != RecaptchaTheme.Default)
-            {
-                var theme = "light";
-
-                if (Theme == RecaptchaTheme.Dark)
-                {
-                    theme = "dark";
-                }
-
-                sb.Append(string.Format(" data-theme=\"{0}\"", theme));
-            }
-
-            if(TabIndex != 0)
-            {
-                sb.Append(string.Format(" data-tabindex=\"{0}\"", TabIndex));
-            }
-
-            if (DataSize != null)
-            {
-                string dataSize = null;
-
-                switch(DataSize)
-                {
-                    case RecaptchaDataSize.Compact:
-                        dataSize = "compact";
-                        break;
-                    default:
-                        dataSize = "normal";
-                        break;
-                }
-
-                sb.Append(string.Format(" data-size=\"{0}\"", dataSize));
-            }
-
-            if (DataType != null)
-            {
-                string dataType = null;
-
-                switch (DataType)
-                {
-                    case RecaptchaDataType.Audio:
-                        dataType = "audio";
-                        break;
-                    default:
-                        dataType = "image";
-                        break;
-                }
-
-                sb.Append(string.Format(" data-type=\"{0}\"", dataType));
-            }
-
-            sb.Append("></div>");
-
-            return sb.ToString();
-        }
-
-        #endregion Public Methods
+      DataType = null;
+      DataSize = null;
     }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>   
+    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
+        : base(publicKey, theme, language, tabIndex)
+    {
+      DataType = null;
+      DataSize = null;
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
+        : base(publicKey, theme, language, tabIndex, useSsl)
+    {
+      DataType = null;
+      DataSize = null;
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="dataType">Sets the type of the recaptcha HTML.</param>
+    /// <param name="dataSize">Sets the size for the recpatcha HTML.</param>
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, RecaptchaDataType? dataType, RecaptchaDataSize? dataSize, SslBehavior useSsl)
+        : base(publicKey, theme, language, tabIndex, useSsl)
+    {
+      DataType = dataType;
+      DataSize = dataSize;
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="Recaptcha2HtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="dataType">Sets the type of the recaptcha HTML.</param>
+    /// <param name="dataSize">Sets the size for the recpatcha HTML.</param>
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
+    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
+    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, RecaptchaDataType? dataType, RecaptchaDataSize? dataSize, SslBehavior useSsl, string dataCallback, string dataExpiredCallback)
+       : base(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback)
+    {
+      DataType = dataType;
+      DataSize = dataSize;
+      DataCallback = dataCallback;
+      DataExpiredCallback = dataExpiredCallback;
+    }
+
+    #endregion Constructors
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the size of the reCAPTCHA control.
+    /// </summary>
+    public RecaptchaDataSize? DataSize
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets they type of the reCAPTCHA control.
+    /// </summary>
+    public RecaptchaDataType? DataType
+    {
+      get;
+      set;
+    }
+
+    #endregion Properties
+
+    #region Public Methods
+
+    /// <summary>
+    /// Gets the recaptcha's HTML that needs to be rendered in an HTML page.
+    /// </summary>
+    /// <returns>Returns the HTML as an instance of the <see cref="String"/> type.</returns>
+    public override string ToString()
+    {
+      StringBuilder sb = new StringBuilder();
+
+      string lang = "";
+
+      if (!String.IsNullOrEmpty(Language))
+      {
+        lang = string.Format("?hl={0}", Language);
+      }
+
+      bool doUseSsl = false;
+
+      if (UseSsl == SslBehavior.DoNotUseSsl)
+      {
+        doUseSsl = false;
+      }
+      else if (UseSsl == SslBehavior.AlwaysUseSsl)
+      {
+        doUseSsl = true;
+      }
+      else if (UseSsl == SslBehavior.SameAsRequestUrl)
+      {
+        doUseSsl = HttpContext.Current.Request.IsSecureConnection;
+      }
+
+      var protocol = "https://";
+
+      if (!doUseSsl)
+      {
+        protocol = "http://";
+      }
+
+      sb.Append(string.Format("<script src=\"{0}www.google.com/recaptcha/api.js{1}\" async defer></script>", protocol, lang));
+      sb.Append(string.Format("<div class=\"g-recaptcha\" data-sitekey=\"{0}\"", PublicKey));
+
+      if (Theme != RecaptchaTheme.Default)
+      {
+        var theme = "light";
+
+        if (Theme == RecaptchaTheme.Dark)
+        {
+          theme = "dark";
+        }
+
+        sb.Append(string.Format(" data-theme=\"{0}\"", theme));
+      }
+
+      if (TabIndex != 0)
+      {
+        sb.Append(string.Format(" data-tabindex=\"{0}\"", TabIndex));
+      }
+
+      if (!String.IsNullOrEmpty(DataCallback))
+      {
+        sb.Append(String.Format(" data-callback=\"{0}\"", DataCallback));
+      }
+
+      if (!String.IsNullOrEmpty(DataExpiredCallback))
+      {
+        sb.Append(String.Format(" data-expired-callback=\"{0}\"", DataExpiredCallback));
+      }
+
+      if (DataSize != null)
+      {
+        string dataSize = null;
+
+        switch (DataSize)
+        {
+          case RecaptchaDataSize.Compact:
+            dataSize = "compact";
+            break;
+          default:
+            dataSize = "normal";
+            break;
+        }
+
+        sb.Append(string.Format(" data-size=\"{0}\"", dataSize));
+      }
+
+      if (DataType != null)
+      {
+        string dataType = null;
+
+        switch (DataType)
+        {
+          case RecaptchaDataType.Audio:
+            dataType = "audio";
+            break;
+          default:
+            dataType = "image";
+            break;
+        }
+
+        sb.Append(string.Format(" data-type=\"{0}\"", dataType));
+      }
+
+      sb.Append("></div>");
+
+      return sb.ToString();
+    }
+
+    #endregion Public Methods
+  }
 }

--- a/src/Recaptcha.Web/RecaptchaHtmlHelper.cs
+++ b/src/Recaptcha.Web/RecaptchaHtmlHelper.cs
@@ -19,17 +19,6 @@ namespace Recaptcha.Web
   public class RecaptchaHtmlHelper : RecaptchaHtmlHelperBase
   {
     #region Constructors
-
-    /// <summary>
-    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
-    /// </summary>
-    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
-    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
-    public RecaptchaHtmlHelper(string dataCallback, string dataCallbackExpired)
-        : base(dataCallback, dataCallbackExpired)
-    { }
-
-
     /// <summary>
     /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
     /// </summary>
@@ -61,21 +50,6 @@ namespace Recaptcha.Web
         : base(publicKey, theme, language, tabIndex, useSsl)
     { }
 
-
-    /// <summary>
-    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
-    /// </summary>
-    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-    /// <param name="language">Sets the language of the recaptcha HTML.</param>
-    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
-    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
-    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
-    public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl, string dataCallback, string dataExpiredCallback)
-        : base(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback)
-    { }
-
     #endregion Constructors
 
     #region Public Methods
@@ -98,17 +72,6 @@ namespace Recaptcha.Web
       }
 
       sb.Append(String.Format("\ntheme : '{0}',\nlang : '{1}',\ntabindex : {2}\n", Theme.ToString().ToLower(), language, TabIndex));
-
-      if (!String.IsNullOrEmpty(DataCallback))
-      {
-        sb.Append(String.Format("\ndata-callback: {0}\n", DataCallback));
-      }
-
-      if (!String.IsNullOrEmpty(DataExpiredCallback))
-      {
-        sb.Append(String.Format("\ndata-expired-callback: {0}\n", DataExpiredCallback));
-      }
-
       sb.Append("};\n</script>");
 
       bool doUseSsl = false;

--- a/src/Recaptcha.Web/RecaptchaHtmlHelper.cs
+++ b/src/Recaptcha.Web/RecaptchaHtmlHelper.cs
@@ -13,95 +13,132 @@ using System.Web;
 
 namespace Recaptcha.Web
 {
+  /// <summary>
+  /// Represents the functionality to generate recaptcha HTML.
+  /// </summary>
+  public class RecaptchaHtmlHelper : RecaptchaHtmlHelperBase
+  {
+    #region Constructors
+
     /// <summary>
-    /// Represents the functionality to generate recaptcha HTML.
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
     /// </summary>
-    public class RecaptchaHtmlHelper : RecaptchaHtmlHelperBase
+    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
+    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelper(string dataCallback, string dataCallbackExpired)
+        : base(dataCallback, dataCallbackExpired)
+    { }
+
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelper(string publicKey)
+        : base(publicKey)
+    { }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>   
+    public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
+        : base(publicKey, theme, language, tabIndex)
+    { }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
+        : base(publicKey, theme, language, tabIndex, useSsl)
+    { }
+
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
+    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl, string dataCallback, string dataExpiredCallback)
+        : base(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback)
+    { }
+
+    #endregion Constructors
+
+    #region Public Methods
+
+    /// <summary>
+    /// Gets the recaptcha's HTML that needs to be rendered in an HTML page.
+    /// </summary>
+    /// <returns>Returns the HTML as an instance of the <see cref="String"/> type.</returns>
+    public override string ToString()
     {
-        #region Constructors
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
-        public RecaptchaHtmlHelper(string publicKey)
-            : base(publicKey)
-        { }
+      StringBuilder sb = new StringBuilder();
 
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>   
-        public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
-            : base(publicKey, theme, language, tabIndex)
-        { }
+      sb.Append("<script type=\"text/javascript\">\nvar RecaptchaOptions = {");
 
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelper"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-        /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
-        public RecaptchaHtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
-            : base(publicKey, theme, language, tabIndex, useSsl)
-        { }
+      string language = this.Language;
 
-        #endregion Constructors
+      if (String.IsNullOrEmpty(language))
+      {
+        language = Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
+      }
 
-        #region Public Methods
+      sb.Append(String.Format("\ntheme : '{0}',\nlang : '{1}',\ntabindex : {2}\n", Theme.ToString().ToLower(), language, TabIndex));
 
-        /// <summary>
-        /// Gets the recaptcha's HTML that needs to be rendered in an HTML page.
-        /// </summary>
-        /// <returns>Returns the HTML as an instance of the <see cref="String"/> type.</returns>
-        public override string ToString()
-        {
-            StringBuilder sb = new StringBuilder();
+      if (!String.IsNullOrEmpty(DataCallback))
+      {
+        sb.Append(String.Format("\ndata-callback: {0}\n", DataCallback));
+      }
 
-            sb.Append("<script type=\"text/javascript\">\nvar RecaptchaOptions = {");
+      if (!String.IsNullOrEmpty(DataExpiredCallback))
+      {
+        sb.Append(String.Format("\ndata-expired-callback: {0}\n", DataExpiredCallback));
+      }
 
-            string language = this.Language;
+      sb.Append("};\n</script>");
 
-            if (String.IsNullOrEmpty(language))
-            {
-                language = Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
-            }
+      bool doUseSsl = false;
 
-            sb.Append(String.Format("\ntheme : '{0}',\nlang : '{1}',\ntabindex : {2}\n", Theme.ToString().ToLower(), language, TabIndex));
-            sb.Append("};\n</script>");
+      if (UseSsl == SslBehavior.DoNotUseSsl)
+      {
+        doUseSsl = false;
+      }
+      else if (UseSsl == SslBehavior.AlwaysUseSsl)
+      {
+        doUseSsl = true;
+      }
+      else if (UseSsl == SslBehavior.SameAsRequestUrl)
+      {
+        doUseSsl = HttpContext.Current.Request.IsSecureConnection;
+      }
 
-            bool doUseSsl = false;
+      var protocol = "https://";
 
-            if(UseSsl == SslBehavior.DoNotUseSsl)
-            {
-                doUseSsl = false;
-            }
-            else if(UseSsl == SslBehavior.AlwaysUseSsl)
-            {
-                doUseSsl = true;
-            }
-            else if(UseSsl == SslBehavior.SameAsRequestUrl)
-            {
-                doUseSsl = HttpContext.Current.Request.IsSecureConnection;
-            }
+      if (!doUseSsl)
+      {
+        protocol = "http://";
+      }
 
-            var protocol = "https://";
+      sb.Append(String.Format("<script type=\"text/javascript\" src=\"{0}www.google.com/recaptcha/api/challenge?k={1}&lang={2}\">", protocol, PublicKey, Language));
+      sb.Append("</script>");
 
-            if (!doUseSsl)
-            {
-                protocol = "http://";
-            }
-
-            sb.Append(String.Format("<script type=\"text/javascript\" src=\"{0}www.google.com/recaptcha/api/challenge?k={1}&lang={2}\">", protocol, PublicKey, Language));
-            sb.Append("</script>");
-
-            return sb.ToString();
-        }
-
-        #endregion Public Methods
+      return sb.ToString();
     }
+
+    #endregion Public Methods
+  }
 }

--- a/src/Recaptcha.Web/RecaptchaHtmlHelperBase.cs
+++ b/src/Recaptcha.Web/RecaptchaHtmlHelperBase.cs
@@ -6,130 +6,188 @@ using System.Threading.Tasks;
 
 namespace Recaptcha.Web
 {
+  /// <summary>
+  /// Represents the base functionality for a reCAPTCHA HTML helper class.
+  /// </summary>
+  public abstract class RecaptchaHtmlHelperBase : IRecaptchaHtmlHelper
+  {
+    #region Constructors
+
+
     /// <summary>
-    /// Represents the base functionality for a reCAPTCHA HTML helper class.
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
     /// </summary>
-    public abstract class RecaptchaHtmlHelperBase : IRecaptchaHtmlHelper
+    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
+    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelperBase(string dataCallback, string dataExpiredCallback)
     {
-        #region Constructors
-
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
-        public RecaptchaHtmlHelperBase(string publicKey)
-        {
-            if (String.IsNullOrEmpty(publicKey))
-            {
-                throw new InvalidOperationException("Public key cannot be null or empty.");
-            }
-
-            this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
-        }
-
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-        public RecaptchaHtmlHelperBase(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
-        {
-            this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
-
-            if (String.IsNullOrEmpty(this.PublicKey))
-            {
-                throw new InvalidOperationException("Public key cannot be null or empty.");
-            }
-
-            this.Theme = theme;
-            this.Language = language;
-            this.TabIndex = tabIndex;
-        }
-
-        /// <summary>
-        /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
-        /// </summary>
-        /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
-        /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
-        /// <param name="language">Sets the language of the recaptcha HTML.</param>
-        /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
-        /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
-        public RecaptchaHtmlHelperBase(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
-        {
-            this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
-
-            if (String.IsNullOrEmpty(this.PublicKey))
-            {
-                throw new InvalidOperationException("Public key cannot be null or empty.");
-            }
-
-            this.Theme = theme;
-            this.Language = language;
-            this.TabIndex = tabIndex;
-
-            UseSsl = useSsl;
-        }
-
-        #endregion Constructors
-
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the ID of the HTML tag that represents recaptcha.
-        /// </summary>
-        public string RecaptchaHtmlId
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets the public key of the recaptcha HTML.
-        /// </summary>
-        public string PublicKey
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Determines if HTTPS intead of HTTP is to be used in reCAPTCHA API calls.
-        /// </summary>
-        public SslBehavior UseSsl
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the theme of the reCAPTCHA HTML.
-        /// </summary>
-        public RecaptchaTheme Theme
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the language of the recaptcha HTML.
-        /// </summary>
-        public string Language
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the tab index of the recaptcha HTML.
-        /// </summary>
-        public int TabIndex
-        {
-            get;
-            set;
-        }
-
-        #endregion Properties
+      this.DataCallback = dataCallback;
+      this.DataExpiredCallback = DataExpiredCallback;
     }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key to be part of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelperBase(string publicKey)
+    {
+      if (String.IsNullOrEmpty(publicKey))
+      {
+        throw new InvalidOperationException("Public key cannot be null or empty.");
+      }
+
+      this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    public RecaptchaHtmlHelperBase(string publicKey, RecaptchaTheme theme, string language, int tabIndex)
+    {
+      this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
+
+      if (String.IsNullOrEmpty(this.PublicKey))
+      {
+        throw new InvalidOperationException("Public key cannot be null or empty.");
+      }
+
+      this.Theme = theme;
+      this.Language = language;
+      this.TabIndex = tabIndex;
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    public RecaptchaHtmlHelperBase(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl)
+    {
+      this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
+
+      if (String.IsNullOrEmpty(this.PublicKey))
+      {
+        throw new InvalidOperationException("Public key cannot be null or empty.");
+      }
+
+      this.Theme = theme;
+      this.Language = language;
+      this.TabIndex = tabIndex;
+
+      UseSsl = useSsl;
+    }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="RecaptchaHtmlHelperBase"/> class.
+    /// </summary>
+    /// <param name="publicKey">Sets the public key of the recaptcha HTML.</param>
+    /// <param name="theme">Sets the theme of the recaptcha HTML.</param>
+    /// <param name="language">Sets the language of the recaptcha HTML.</param>
+    /// <param name="tabIndex">Sets the tab index of the recaptcha HTML.</param>    
+    /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
+    /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
+    /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
+    public RecaptchaHtmlHelperBase(string publicKey, RecaptchaTheme theme, string language, int tabIndex, SslBehavior useSsl, string dataCallback, string dataExpiredCallback)
+    {
+      this.PublicKey = RecaptchaKeyHelper.ParseKey(publicKey);
+
+      if (String.IsNullOrEmpty(this.PublicKey))
+      {
+        throw new InvalidOperationException("Public key cannot be null or empty.");
+      }
+
+      this.Theme = theme;
+      this.Language = language;
+      this.TabIndex = tabIndex;
+      this.DataCallback = dataCallback;
+      this.DataExpiredCallback = DataExpiredCallback;
+
+      UseSsl = useSsl;
+    }
+
+    #endregion Constructors
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the ID of the HTML tag that represents recaptcha.
+    /// </summary>
+    public string RecaptchaHtmlId
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets the public key of the recaptcha HTML.
+    /// </summary>
+    public string PublicKey
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Determines if HTTPS intead of HTTP is to be used in reCAPTCHA API calls.
+    /// </summary>
+    public SslBehavior UseSsl
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets the theme of the reCAPTCHA HTML.
+    /// </summary>
+    public RecaptchaTheme Theme
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets the language of the recaptcha HTML.
+    /// </summary>
+    public string Language
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets the tab index of the recaptcha HTML.
+    /// </summary>
+    public int TabIndex
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets the data-callback of the recaptcha HTML.
+    /// </summary>
+    public string DataCallback
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// Gets or sets the data-expired-callback for the recaptcha HTML.
+    /// </summary>
+    public string DataExpiredCallback
+    {
+      get;
+      set;
+    }
+
+    #endregion Properties
+  }
 }

--- a/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
+++ b/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
@@ -307,7 +307,7 @@ namespace Recaptcha.Web.UI.Controls
 
         if (apiVersion != "2")
         {
-          htmlHelper = new RecaptchaHtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.UseSsl, this.DataCallback, this.DataExpiredCallback);
+          htmlHelper = new RecaptchaHtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.UseSsl);
         }
         else
         {

--- a/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
+++ b/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
@@ -16,300 +16,344 @@ using System.Web.UI.WebControls;
 
 namespace Recaptcha.Web.UI.Controls
 {
+  /// <summary>
+  /// An ASP.NET control that wraps Google's recaptcha control.
+  /// </summary>
+  [DefaultProperty("PublicKey")]
+  [ToolboxData("<{0}:Recaptcha runat=server></{0}:Recaptcha>")]
+  public class Recaptcha : WebControl
+  {
+    #region Fields
+
+    private RecaptchaVerificationHelper _verificationHelper = null;
+
+    #endregion Fields
+
+    #region Properties
+
     /// <summary>
-    /// An ASP.NET control that wraps Google's recaptcha control.
+    /// Gets or sets the API version of the recaptcha control.
     /// </summary>
-    [DefaultProperty("PublicKey")]
-    [ToolboxData("<{0}:Recaptcha runat=server></{0}:Recaptcha>")]
-    public class Recaptcha : WebControl
+    /// <remarks>The value of the <see cref="ApiVersion"/> property is optional. If the value is not set, version 1 is automatically assumed.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue("{recaptchaApiVersion}")]
+    [Localizable(false)]
+    public string ApiVersion
     {
-        #region Fields
+      get
+      {
+        String s = (String)ViewState["ApiVersion"];
+        return ((s == null) ? "{recaptchaApiVersion}" : s);
+      }
 
-        private RecaptchaVerificationHelper _verificationHelper = null;
-
-        #endregion Fields
-
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the API version of the recaptcha control.
-        /// </summary>
-        /// <remarks>The value of the <see cref="ApiVersion"/> property is optional. If the value is not set, version 1 is automatically assumed.</remarks>
-        [Bindable(true)]
-        [Category("Behavior")]
-        [DefaultValue("{recaptchaApiVersion}")]
-        [Localizable(false)]
-        public string ApiVersion
-        {
-            get
-            {
-                String s = (String)ViewState["ApiVersion"];
-                return ((s == null) ? "{recaptchaApiVersion}" : s);
-            }
-
-            set
-            {
-                ViewState["ApiVersion"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the public key of the recaptcha control.
-        /// </summary>
-        /// <remarks>The value of the <see cref="PublicKey"/> property is required. If the key is not set, a runtime exception will be thrown. The key can be set either directly as a literal value or as an appSettings key from the application configuration file. An appSettings key needs to be specified within {} curly braces.</remarks>
-        [Bindable(true)]
-        [Category("Behavior")]
-        [DefaultValue("{recaptchaPublicKey}")]
-        [Localizable(false)]
-        public string PublicKey
-        {
-            get
-            {
-                String s = (String)ViewState["PublicKey"];
-                return ((s == null) ? "{recaptchaPublicKey}" : s);
-            }
-
-            set
-            {
-                ViewState["PublicKey"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the private key of the recaptcha control.
-        /// </summary>
-        /// <remarks>The value of the <see cref="PrivateKey"/> property is required. If the key is not set, a runtime exception will be thrown. The key can be set either directly as a literal value or as an appSettings key from the application configuration file. An appSettings key needs to be specified within {} curly braces.</remarks>
-        [Bindable(true)]
-        [Category("Behavior")]
-        [DefaultValue("{recaptchaPrivateKey}")]
-        [Localizable(false)]
-        public string PrivateKey
-        {
-            get
-            {
-                String s = (String)ViewState["PrivateKey"];
-                return ((s == null) ? "{recaptchaPrivateKey}" : s);
-            }
-            set
-            {
-                ViewState["PrivateKey"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the theme of the recaptcha control.
-        /// </summary>
-        [Bindable(true)]
-        [Category("Appearance")]
-        [DefaultValue(RecaptchaTheme.Red)]
-        [Localizable(false)]
-        public RecaptchaTheme Theme
-        {
-            get
-            {
-                object t = ViewState["RecaptchaTheme"];
-                return ((t == null) ? RecaptchaTheme.Red : (RecaptchaTheme)t);
-            }
-
-            set
-            {
-                ViewState["RecaptchaTheme"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the language of the recaptcha control.
-        /// </summary>
-        /// <remarks>If the property is not set then the language of the current UI culture will be used.</remarks>
-        [Bindable(true)]
-        [Category("Appearance")]
-        [Localizable(false)]
-        public string Language
-        {
-            get
-            {
-                return ViewState["RecaptchaLanguage"] as string;
-            }
-
-            set
-            {
-                ViewState["RecaptchaLanguage"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether to use SSL in reCAPTCHA URLs.
-        /// </summary>
-        /// <remarks>The default value is <see cref="SslBehavior.SameAsRequestUrl"/>.</remarks>
-        [Bindable(true)]
-        [Category("Behavior")]
-        [DefaultValue(false)]
-        [Localizable(false)]
-        public SslBehavior UseSsl
-        {
-            get
-            {
-                if(ViewState["UseSsl"] == null)
-                {
-                    ViewState["UseSsl"] = SslBehavior.SameAsRequestUrl.ToString();
-                }
-
-                return (SslBehavior) Enum.Parse(typeof(SslBehavior), ViewState["UseSsl"].ToString());
-            }
-
-            set
-            {
-                ViewState["UseSsl"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the user's response to the recaptcha challenge.
-        /// </summary>
-        [Bindable(true)]
-        [Category("Appearance")]
-        [Localizable(false)]
-        public string Response
-        {
-            get
-            {
-                if (_verificationHelper != null)
-                {
-                    return _verificationHelper.Response;
-                }
-
-                return String.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the data size of the recaptcha control.
-        /// </summary>
-        /// <remarks>This property is only relevant for v2 API. It has no effect if you are using v1 API.</remarks>
-        [Bindable(true)]
-        [Category("Appearance")]
-        [DefaultValue(RecaptchaDataSize.Normal)]
-        [Localizable(false)]
-        public RecaptchaDataSize DataSize
-        {
-            get
-            {
-                object t = ViewState["RecaptchaDataSize"];
-                return ((t == null) ? RecaptchaDataSize.Normal : (RecaptchaDataSize)t);
-            }
-
-            set
-            {
-                ViewState["RecaptchaDataSize"] = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the data size of the recaptcha control.
-        /// </summary>
-        /// <remarks>This property is only relevant for v2 API. It has no effect if you are using v1 API.</remarks>
-        [Bindable(true)]
-        [Category("Appearance")]
-        [DefaultValue(RecaptchaDataType.Image)]
-        [Localizable(false)]
-        public RecaptchaDataType DataType
-        {
-            get
-            {
-                object t = ViewState["RecaptchaDataType"];
-                return ((t == null) ? RecaptchaDataType.Image : (RecaptchaDataType)t);
-            }
-
-            set
-            {
-                ViewState["RecaptchaDataType"] = value;
-            }
-        }
-
-        #endregion Properties
-
-        #region Control Events
-
-        /// <summary>
-        /// Calls the OnLoad method of the parent class <see cref="System.Web.UI.WebControls.WebControl"/> and initializes the internal state of the <see cref="Recaptcha"/> control for verification of the user's response to the recaptcha challenge.
-        /// </summary>
-        /// <param name="e">The <see cref="EventArgs"/> object passed to the Load event of the control.</param>
-        protected override void OnLoad(EventArgs e)
-        {
-            base.OnLoad(e);
-
-            if (this.Page.IsPostBack)
-            {
-                _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
-            }
-        }
-
-        /// <summary>
-        /// Redners the HTML output. This method is automatically called by ASP.NET during the rendering process.
-        /// </summary>
-        /// <param name="output">The output object to which the method will write HTML to.</param>
-        /// <exception cref="InvalidOperationException">The exception is thrown if the public key is not set.</exception>
-        protected override void RenderContents(HtmlTextWriter output)
-        {
-            if (this.DesignMode)
-            {
-                output.Write("<p>Recaptcha Control</p>");
-            }
-            else
-            {
-                IRecaptchaHtmlHelper htmlHelper = null;
-
-                string apiVersion = RecaptchaKeyHelper.ParseKey(ApiVersion);
-
-                if (apiVersion != "2")
-                {
-                    htmlHelper = new RecaptchaHtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.UseSsl);
-                }
-                else
-                {
-                    htmlHelper = new Recaptcha2HtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.DataType, this.DataSize, this.UseSsl);
-                }
-                
-                output.Write(htmlHelper.ToString());
-            }
-        }
-
-        #endregion Control Events
-
-        #region Public Methods
-
-        /// <summary>
-        /// Verifies the user's answer to the recaptcha challenge.
-        /// </summary>
-        /// <returns>Returns the verification result as <see cref="RecaptchaVerificationResult"/> enum value.</returns>
-        ///<exception cref="InvalidOperationException">The private key is null or empty.</exception>
-        ///<exception cref="System.Net.WebException">The time-out period for the recaptcha verification request expired.</exception>
-        public RecaptchaVerificationResult Verify()
-        {
-            if (_verificationHelper == null)
-            {
-                _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
-            }
-
-            return _verificationHelper.VerifyRecaptchaResponse();
-        }
-
-        /// <summary>
-        /// Verifies the user's answer to the recaptcha challenge.
-        /// </summary>
-        /// <returns>Returns the verification result as <see cref="RecaptchaVerificationResult"/> enum value.</returns>
-        ///<exception cref="InvalidOperationException">The private key is null or empty.</exception>
-        ///<exception cref="System.Net.WebException">The time-out period for the recaptcha verification request expired.</exception>
-        public Task<RecaptchaVerificationResult> VerifyTaskAsync()
-        {
-            if (_verificationHelper == null)
-            {
-                _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
-            }
-
-            return _verificationHelper.VerifyRecaptchaResponseTaskAsync();
-        }
-
-        #endregion Public Methods
+      set
+      {
+        ViewState["ApiVersion"] = value;
+      }
     }
+
+    /// <summary>
+    /// Gets or sets the public key of the recaptcha control.
+    /// </summary>
+    /// <remarks>The value of the <see cref="PublicKey"/> property is required. If the key is not set, a runtime exception will be thrown. The key can be set either directly as a literal value or as an appSettings key from the application configuration file. An appSettings key needs to be specified within {} curly braces.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue("{recaptchaPublicKey}")]
+    [Localizable(false)]
+    public string PublicKey
+    {
+      get
+      {
+        String s = (String)ViewState["PublicKey"];
+        return ((s == null) ? "{recaptchaPublicKey}" : s);
+      }
+
+      set
+      {
+        ViewState["PublicKey"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the private key of the recaptcha control.
+    /// </summary>
+    /// <remarks>The value of the <see cref="PrivateKey"/> property is required. If the key is not set, a runtime exception will be thrown. The key can be set either directly as a literal value or as an appSettings key from the application configuration file. An appSettings key needs to be specified within {} curly braces.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue("{recaptchaPrivateKey}")]
+    [Localizable(false)]
+    public string PrivateKey
+    {
+      get
+      {
+        String s = (String)ViewState["PrivateKey"];
+        return ((s == null) ? "{recaptchaPrivateKey}" : s);
+      }
+      set
+      {
+        ViewState["PrivateKey"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the theme of the recaptcha control.
+    /// </summary>
+    [Bindable(true)]
+    [Category("Appearance")]
+    [DefaultValue(RecaptchaTheme.Red)]
+    [Localizable(false)]
+    public RecaptchaTheme Theme
+    {
+      get
+      {
+        object t = ViewState["RecaptchaTheme"];
+        return ((t == null) ? RecaptchaTheme.Red : (RecaptchaTheme)t);
+      }
+
+      set
+      {
+        ViewState["RecaptchaTheme"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the language of the recaptcha control.
+    /// </summary>
+    /// <remarks>If the property is not set then the language of the current UI culture will be used.</remarks>
+    [Bindable(true)]
+    [Category("Appearance")]
+    [Localizable(false)]
+    public string Language
+    {
+      get
+      {
+        return ViewState["RecaptchaLanguage"] as string;
+      }
+
+      set
+      {
+        ViewState["RecaptchaLanguage"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether to use SSL in reCAPTCHA URLs.
+    /// </summary>
+    /// <remarks>The default value is <see cref="SslBehavior.SameAsRequestUrl"/>.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue(false)]
+    [Localizable(false)]
+    public SslBehavior UseSsl
+    {
+      get
+      {
+        if (ViewState["UseSsl"] == null)
+        {
+          ViewState["UseSsl"] = SslBehavior.SameAsRequestUrl.ToString();
+        }
+
+        return (SslBehavior)Enum.Parse(typeof(SslBehavior), ViewState["UseSsl"].ToString());
+      }
+
+      set
+      {
+        ViewState["UseSsl"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets the user's response to the recaptcha challenge.
+    /// </summary>
+    [Bindable(true)]
+    [Category("Appearance")]
+    [Localizable(false)]
+    public string Response
+    {
+      get
+      {
+        if (_verificationHelper != null)
+        {
+          return _verificationHelper.Response;
+        }
+
+        return String.Empty;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the data size of the recaptcha control.
+    /// </summary>
+    /// <remarks>This property is only relevant for v2 API. It has no effect if you are using v1 API.</remarks>
+    [Bindable(true)]
+    [Category("Appearance")]
+    [DefaultValue(RecaptchaDataSize.Normal)]
+    [Localizable(false)]
+    public RecaptchaDataSize DataSize
+    {
+      get
+      {
+        object t = ViewState["RecaptchaDataSize"];
+        return ((t == null) ? RecaptchaDataSize.Normal : (RecaptchaDataSize)t);
+      }
+
+      set
+      {
+        ViewState["RecaptchaDataSize"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the data size of the recaptcha control.
+    /// </summary>
+    /// <remarks>This property is only relevant for v2 API. It has no effect if you are using v1 API.</remarks>
+    [Bindable(true)]
+    [Category("Appearance")]
+    [DefaultValue(RecaptchaDataType.Image)]
+    [Localizable(false)]
+    public RecaptchaDataType DataType
+    {
+      get
+      {
+        object t = ViewState["RecaptchaDataType"];
+        return ((t == null) ? RecaptchaDataType.Image : (RecaptchaDataType)t);
+      }
+
+      set
+      {
+        ViewState["RecaptchaDataType"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the data-callback of recaptcha control.
+    /// </summary>
+    /// <remarks>The value of the <see cref="DataCallback"/> property is optional.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue("")]
+    [Localizable(false)]
+    public string DataCallback
+    {
+      get
+      {
+        String s = (String)ViewState["DataCallback"];
+        return ((s == null) ? "" : s);
+      }
+
+      set
+      {
+        ViewState["DataCallback"] = value;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the data-expired-callback of recaptcha control.
+    /// </summary>
+    /// <remarks>The value of the <see cref="DataExpiredCallback"/> property is optional.</remarks>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [DefaultValue("")]
+    [Localizable(false)]
+    public string DataExpiredCallback
+    {
+      get
+      {
+        String s = (String)ViewState["DataExpiredCallback"];
+        return ((s == null) ? "" : s);
+      }
+
+      set
+      {
+        ViewState["DataExpiredCallback"] = value;
+      }
+    }
+
+    #endregion Properties
+
+    #region Control Events
+
+    /// <summary>
+    /// Calls the OnLoad method of the parent class <see cref="System.Web.UI.WebControls.WebControl"/> and initializes the internal state of the <see cref="Recaptcha"/> control for verification of the user's response to the recaptcha challenge.
+    /// </summary>
+    /// <param name="e">The <see cref="EventArgs"/> object passed to the Load event of the control.</param>
+    protected override void OnLoad(EventArgs e)
+    {
+      base.OnLoad(e);
+
+      if (this.Page.IsPostBack)
+      {
+        _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
+      }
+    }
+
+    /// <summary>
+    /// Redners the HTML output. This method is automatically called by ASP.NET during the rendering process.
+    /// </summary>
+    /// <param name="output">The output object to which the method will write HTML to.</param>
+    /// <exception cref="InvalidOperationException">The exception is thrown if the public key is not set.</exception>
+    protected override void RenderContents(HtmlTextWriter output)
+    {
+      if (this.DesignMode)
+      {
+        output.Write("<p>Recaptcha Control</p>");
+      }
+      else
+      {
+        IRecaptchaHtmlHelper htmlHelper = null;
+
+        string apiVersion = RecaptchaKeyHelper.ParseKey(ApiVersion);
+
+        if (apiVersion != "2")
+        {
+          htmlHelper = new RecaptchaHtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.UseSsl, this.DataCallback, this.DataExpiredCallback);
+        }
+        else
+        {
+          htmlHelper = new Recaptcha2HtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.DataType, this.DataSize, this.UseSsl, this.DataCallback, this.DataExpiredCallback);
+        }
+
+        output.Write(htmlHelper.ToString());
+      }
+    }
+
+    #endregion Control Events
+
+    #region Public Methods
+
+    /// <summary>
+    /// Verifies the user's answer to the recaptcha challenge.
+    /// </summary>
+    /// <returns>Returns the verification result as <see cref="RecaptchaVerificationResult"/> enum value.</returns>
+    ///<exception cref="InvalidOperationException">The private key is null or empty.</exception>
+    ///<exception cref="System.Net.WebException">The time-out period for the recaptcha verification request expired.</exception>
+    public RecaptchaVerificationResult Verify()
+    {
+      if (_verificationHelper == null)
+      {
+        _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
+      }
+
+      return _verificationHelper.VerifyRecaptchaResponse();
+    }
+
+    /// <summary>
+    /// Verifies the user's answer to the recaptcha challenge.
+    /// </summary>
+    /// <returns>Returns the verification result as <see cref="RecaptchaVerificationResult"/> enum value.</returns>
+    ///<exception cref="InvalidOperationException">The private key is null or empty.</exception>
+    ///<exception cref="System.Net.WebException">The time-out period for the recaptcha verification request expired.</exception>
+    public Task<RecaptchaVerificationResult> VerifyTaskAsync()
+    {
+      if (_verificationHelper == null)
+      {
+        _verificationHelper = new RecaptchaVerificationHelper(this.PrivateKey);
+      }
+
+      return _verificationHelper.VerifyRecaptchaResponseTaskAsync();
+    }
+
+    #endregion Public Methods
+  }
 }


### PR DESCRIPTION
This extends the control with the data-callback and data-expired-callback properties.
So one can enable/disable a submit button:
```
 @Html.Recaptcha(dataCallback: "capenable", dataExpiredCallback: "capdisable")
...
 <input type="submit" class="btn btn-default" value="Register" />
   ...
<script type="text/javascript">
        function capenable() {
            $('input[type="submit"]').prop('disabled', false);
        }
        function capdisable() {
            $('input[type="submit"]').prop('disabled', true);
        }
        $(document).ready(function () {
            capdisable();
        });
    </script>
```