### PR TITLE
Added fix for #7 (option to disable script tag rendering).

### DIFF
--- a/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
+++ b/src/Recaptcha.Web/Mvc/RecaptchaMvcExtensions.cs
@@ -47,7 +47,8 @@ namespace Recaptcha.Web.Mvc
         SslBehavior useSsl = SslBehavior.SameAsRequestUrl,
         string apiVersion = "{recaptchaApiVersion}",
         string dataCallback = "",
-        string dataExpiredCallback = "")
+        string dataExpiredCallback = "",
+        bool renderApiScriptTag = true)
     {
       IRecaptchaHtmlHelper rHtmlHelper = null;
 
@@ -59,7 +60,7 @@ namespace Recaptcha.Web.Mvc
       }
       else
       {
-        rHtmlHelper = new Recaptcha2HtmlHelper(publicKey, theme, language, tabIndex, dataType, dataSize, useSsl, dataCallback, dataExpiredCallback);
+        rHtmlHelper = new Recaptcha2HtmlHelper(publicKey, theme, language, tabIndex, dataType, dataSize, useSsl, dataCallback, dataExpiredCallback, renderApiScriptTag);
       }
 
       var writer = new HtmlTextWriter(new StringWriter());

--- a/src/Recaptcha.Web/Recaptcha.Web.csproj
+++ b/src/Recaptcha.Web/Recaptcha.Web.csproj
@@ -42,7 +42,8 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>Recaptcha.pfx</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -106,7 +107,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="Recaptcha.pfx" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Recaptcha.Web/Recaptcha2HtmlHelper.cs
+++ b/src/Recaptcha.Web/Recaptcha2HtmlHelper.cs
@@ -89,13 +89,14 @@ namespace Recaptcha.Web
     /// <param name="useSsl">Determines whether to use SSL in reCAPTCHA API URLs.</param>
     /// <param name="dataCallback">Sets the data-callback property of the recaptcha HTML.</param>    
     /// <param name="dataExpiredCallback">Sets the data-expired-callback property of the recaptcha HTML.</param>
-    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, RecaptchaDataType? dataType, RecaptchaDataSize? dataSize, SslBehavior useSsl, string dataCallback, string dataExpiredCallback)
+    public Recaptcha2HtmlHelper(string publicKey, RecaptchaTheme theme, string language, int tabIndex, RecaptchaDataType? dataType, RecaptchaDataSize? dataSize, SslBehavior useSsl, string dataCallback, string dataExpiredCallback, bool renderApiScriptTag)
        : base(publicKey, theme, language, tabIndex, useSsl, dataCallback, dataExpiredCallback)
     {
       DataType = dataType;
       DataSize = dataSize;
       DataCallback = dataCallback;
       DataExpiredCallback = dataExpiredCallback;
+      RenderApiScriptTag = renderApiScriptTag;
     }
 
     #endregion Constructors
@@ -161,7 +162,9 @@ namespace Recaptcha.Web
         protocol = "http://";
       }
 
-      sb.Append(string.Format("<script src=\"{0}www.google.com/recaptcha/api.js{1}\" async defer></script>", protocol, lang));
+      if (RenderApiScriptTag) 
+        sb.Append(string.Format("<script src=\"{0}www.google.com/recaptcha/api.js{1}\" async defer></script>", protocol, lang));
+
       sb.Append(string.Format("<div class=\"g-recaptcha\" data-sitekey=\"{0}\"", PublicKey));
 
       if (Theme != RecaptchaTheme.Default)

--- a/src/Recaptcha.Web/RecaptchaHtmlHelperBase.cs
+++ b/src/Recaptcha.Web/RecaptchaHtmlHelperBase.cs
@@ -187,6 +187,15 @@ namespace Recaptcha.Web
       get;
       set;
     }
+      
+    /// <summary>
+    /// Determines if the script tag should be rendered.
+    /// </summary>
+    public bool RenderApiScriptTag
+    {
+      get;
+      set;
+    }
 
     #endregion Properties
   }

--- a/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
+++ b/src/Recaptcha.Web/UI/Controls/Recaptcha.cs
@@ -239,7 +239,7 @@ namespace Recaptcha.Web.UI.Controls
       get
       {
         String s = (String)ViewState["DataCallback"];
-        return ((s == null) ? "" : s);
+        return (s ?? "");
       }
 
       set
@@ -261,7 +261,7 @@ namespace Recaptcha.Web.UI.Controls
       get
       {
         String s = (String)ViewState["DataExpiredCallback"];
-        return ((s == null) ? "" : s);
+        return (s ?? "");
       }
 
       set
@@ -269,6 +269,31 @@ namespace Recaptcha.Web.UI.Controls
         ViewState["DataExpiredCallback"] = value;
       }
     }
+
+    /// <summary>
+    /// Determines if the Api Script Tag should be rendered.
+    /// </summary>
+    [Bindable(true)]
+    [Category("Behavior")]
+    [Localizable(false)]
+    public bool RenderApiScriptTag
+    {
+      get
+      {
+          bool? s = (bool?)ViewState["RenderApiScriptTag"];
+          return (s ?? true);
+      }
+
+      set
+      {
+          ViewState["RenderApiScriptTag"] = value;
+      }
+    }
+
+
+
+
+      
 
     #endregion Properties
 
@@ -311,7 +336,7 @@ namespace Recaptcha.Web.UI.Controls
         }
         else
         {
-          htmlHelper = new Recaptcha2HtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.DataType, this.DataSize, this.UseSsl, this.DataCallback, this.DataExpiredCallback);
+            htmlHelper = new Recaptcha2HtmlHelper(this.PublicKey, this.Theme, this.Language, this.TabIndex, this.DataType, this.DataSize, this.UseSsl, this.DataCallback, this.DataExpiredCallback, this.RenderApiScriptTag);
         }
 
         output.Write(htmlHelper.ToString());


### PR DESCRIPTION
With this, we can now use two recaptchas in the same page.

Inside of the <head> tag, manually load the api script:

`<script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" async defer></script>`

Then in the bottom of the page, insert this javascript to manually render recaptchas:

`<script type="text/javascript">
  var CaptchaCallback = function() {
    $('.g-recaptcha').each(function(index, el) {
      grecaptcha.render(el, {'sitekey' : 'your_key'});
    });
  };
</script>`

Then insert as many repactchas as you wish with this:

`@Html.Recaptcha(renderApiScript: false)`