### PR TITLE
Add support for Razor Pages in netcoreapp-3.1

### DIFF
--- a/src/Recaptcha.Web-netcoreapp3.1/Mvc/RecaptchaMvcExtensions.cs
+++ b/src/Recaptcha.Web-netcoreapp3.1/Mvc/RecaptchaMvcExtensions.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Recaptcha.Web.Configuration;
 using System;
@@ -152,6 +153,28 @@ namespace Recaptcha.Web.Mvc
         {
             var config = RecaptchaConfigurationManager.GetConfiguration();
             return new RecaptchaVerificationHelper(controller.HttpContext, config.SecretKey);
+        }
+
+        /// <summary>
+        /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
+        /// </summary>
+        /// <param name="pageModel">The <see cref="Microsoft.AspNetCore.Mvc.RazorPages.PageModel"/> object to which the extension method is added to.</param>
+        /// <param name="secretKey">The private key required for making the recaptcha verification request.</param>
+        /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
+        public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this PageModel pageModel, string secretKey)
+        {
+            return new RecaptchaVerificationHelper(pageModel.HttpContext, secretKey);
+        }
+
+        /// <summary>
+        /// Gets an instance of the <see cref="RecaptchaVerificationHelper"/> class that can be used to verify user's response to the recaptcha's challenge. 
+        /// </summary>
+        /// <param name="pageModel">The <see cref="Microsoft.AspNetCore.Mvc.RazorPages.PageModel"/> object to which the extension method is added to.</param>
+        /// <returns>Returns an instance of the <see cref="RecaptchaVerificationHelper"/> class.</returns>
+        public static RecaptchaVerificationHelper GetRecaptchaVerificationHelper(this PageModel pageModel)
+        {
+            var config = RecaptchaConfigurationManager.GetConfiguration();
+            return new RecaptchaVerificationHelper(pageModel.HttpContext, config.SecretKey);
         }
 
         #endregion Public Methods

--- a/src/Recaptcha.Web-netcoreapp3.1/Recaptcha.Web-netcoreapp3.1.csproj
+++ b/src/Recaptcha.Web-netcoreapp3.1/Recaptcha.Web-netcoreapp3.1.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Currently this cannot be used in Razor Pages (e.g. the built-in ASP.NET Core Identity default pages) as the only public way of getting a `RecaptchaVerificationHelper` is an extension method on `System.Web.Mvc.Controller` since the constructor is declared `internal`.

This provides extension methods on `Microsoft.AspNetCore.Mvc.RazorPages.PageModel` which should require no changes to the example code, other than to mention that it (probably) goes in `PageModel.OnPostAsync` rather than a controller method decorated with `HttpPost`.